### PR TITLE
Add option to put created vm into a pool

### DIFF
--- a/src/molecule_proxmox/playbooks/create.yml
+++ b/src/molecule_proxmox/playbooks/create.yml
@@ -26,6 +26,8 @@
         name: "{{ p.name }}"
         node: "{{ options.node }}"
         timeout: "{{ options.timeout | d(omit) }}"
+        pool: "{{ d(options.pool) | d(omit) }}"
+        newid: "{{ p.newid | d(p.newid, true) | d(omit, true) }}"
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         loop_var: p


### PR DESCRIPTION
This PR adds the option `pool` into the create.yml file. Creating a vm with molecule then tries to add this vm automatically into the given pool. The other steps (prepare, destroy) only use the vmid to determine the virtual machine and therefore don't rely on the `pool`option.

The pool option can be found here: https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_kvm_module.html#parameter-pool