### PR TITLE
Add requests to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
         'molecule>=6.0.0',
         'PyYAML',
         'proxmoxer>=1.3.1',
+        'requests',
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Proxmoxer supports different authentication backends and therefore does not require `requests` to be installed. But the `proxmox_kvm` module **only** supports http, while not being a pip module and thus not being able to install a package.

Since `molecule-proxmox` requires `proxmox_kvm`, it should require `requests` as well to work out of the box after installing it into an empty virtualenv.