### PR TITLE
Add requests and add ssh_port to options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ Examples
         api_password: "********"
         node: pve01
         ssh_user: tester
+        ssh_port: 22022             # default to 22
         ssh_identity_file: /path/to/id_rsa
    platforms:
      - name: test01
@@ -85,6 +86,7 @@ Examples
         api_token_secret: "*******************************"
         node: pve01
         ssh_user: tester
+        ssh_port: 22022             # default to 22
         ssh_identity_file: /path/to/id_rsa
         # Optional: The default template name.
         template_name: debian11
@@ -109,6 +111,7 @@ Examples
         proxmox_secrets: /path/to/proxmox_secrets.yml"
         node: pve01
         ssh_user: tester
+        ssh_port: 22022             # default to 22
         ssh_identity_file: /path/to/id_rsa
         template_name: debian11
    platforms:
@@ -124,6 +127,7 @@ Examples
         proxmox_secrets: /path/to/proxmox_secrets.yml"
         node: pve01
         ssh_user: tester
+        ssh_port: 22022             # default to 22
         ssh_identity_file: /path/to/id_rsa
         template_name: debian11
    platforms:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
         'molecule>=6.0.0',
         'PyYAML',
         'proxmoxer>=1.3.1',
+        'requests'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/src/molecule_proxmox/playbooks/create.yml
+++ b/src/molecule_proxmox/playbooks/create.yml
@@ -85,7 +85,7 @@
           instance: "{{ ra.rc.p.name }}"
           address: "{{ ra.addresses[0] }}"
           user: "{{ options.ssh_user | d('molecule') }}"
-          port: 22
+          port: "{{ options.ssh_port | d('22') }}"
           identity_file: "{{ options.ssh_identity_file }}"
           vmid: "{{ ra.vmid }}"
       loop: "{{ proxmox_qemu_agent.results }}"


### PR DESCRIPTION
In our infra, we are doing the whole templates with custom ssh port, which was not supported by your module. in this change I'm reading the `ssh_port` from the options but also with a fallback to 22.
The other change is dependency to `requests` module.