### PR TITLE
Pin molecule version to 25.1.0 or less

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     },
     install_requires=[
         # molecule plugins are not allowed to mention Ansible as a direct dependency
-        'molecule>=6.0.0',
+        'molecule<=25.2.0',
         'PyYAML',
         'proxmoxer>=1.3.1',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     },
     install_requires=[
         # molecule plugins are not allowed to mention Ansible as a direct dependency
-        'molecule<=25.2.0',
+        'molecule<=25.1.0',
         'PyYAML',
         'proxmoxer>=1.3.1',
         'requests',


### PR DESCRIPTION
My local setup just died due to past reworks of molecule - see this release: https://github.com/ansible/molecule/releases/tag/v25.2.0

All in all, the custom qemu-agent script os not found anymore by molecule. Therefore installing molecule right now will lead to a probably broken test environment and user unfriendly debugging.

I propose:
- We pin to 25.1.0 since it is known to work out of the box with molecule-proxmox
- We rework the create playbook to not rely on a custom module but instead use `community.general.proxmox_*`. These modules should offer the same functionality.

We could use [proxmox_vm_info](https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_vm_info_module.html) for the ip info from the guest agent and [proxmox_kvm](https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_kvm_module.html) to start the vm. This would further reduce complexity of this project and centralize the interaction logic of proxmox towards community.general.proxmox*.