### PR TITLE
tests: Optionally use linked clones in tests

### DIFF
--- a/tests/proxmox_driver/molecule/by-name/molecule.yml
+++ b/tests/proxmox_driver/molecule/by-name/molecule.yml
@@ -12,6 +12,7 @@ driver:
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
     # Default template name. Defaults to 'molecule' if not set.
     template_name: "${TEST_PROXMOX_TEMPLATE_NAME}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     timeout: 120
     debug: "${TEST_PROXMOX_DEBUG}"
 

--- a/tests/proxmox_driver/molecule/by-vmid/molecule.yml
+++ b/tests/proxmox_driver/molecule/by-vmid/molecule.yml
@@ -11,6 +11,7 @@ driver:
     node: "${TEST_PROXMOX_NODE}"
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     timeout: 120
     debug: "${TEST_PROXMOX_DEBUG}"
 

--- a/tests/proxmox_driver/molecule/cloud-init/molecule.yml
+++ b/tests/proxmox_driver/molecule/cloud-init/molecule.yml
@@ -11,6 +11,7 @@ driver:
     node: "${TEST_PROXMOX_NODE}"
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     debug: "${TEST_PROXMOX_DEBUG}"
 
 platforms:

--- a/tests/proxmox_driver/molecule/default/molecule.yml
+++ b/tests/proxmox_driver/molecule/default/molecule.yml
@@ -13,6 +13,7 @@ driver:
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
     template_name: "${TEST_PROXMOX_TEMPLATE_NAME}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     debug: "${TEST_PROXMOX_DEBUG}"
 
 platforms:

--- a/tests/proxmox_driver/molecule/linked-clone/molecule.yml
+++ b/tests/proxmox_driver/molecule/linked-clone/molecule.yml
@@ -10,10 +10,10 @@ driver:
     api_user: "${TEST_PROXMOX_USER}"
     api_password: "${TEST_PROXMOX_PASSWORD}"
     node: "${TEST_PROXMOX_NODE}"
-    full: "${TEST_PROXMOX_FULL_CLONE:-false}"
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
     template_name: "${TEST_PROXMOX_TEMPLATE_NAME}"
+    full: "false"
     debug: "${TEST_PROXMOX_DEBUG}"
 
 platforms:

--- a/tests/proxmox_driver/molecule/secrets-file/molecule.yml
+++ b/tests/proxmox_driver/molecule/secrets-file/molecule.yml
@@ -10,6 +10,7 @@ driver:
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
     template_name: "${TEST_PROXMOX_TEMPLATE_NAME}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     debug: "${TEST_PROXMOX_DEBUG}"
 
 platforms:

--- a/tests/proxmox_driver/molecule/secrets-script/molecule.yml
+++ b/tests/proxmox_driver/molecule/secrets-script/molecule.yml
@@ -10,6 +10,7 @@ driver:
     ssh_user: "${TEST_PROXMOX_SSH_USER}"
     ssh_identity_file: "${TEST_PROXMOX_SSH_IDENTITY_FILE}"
     template_name: "${TEST_PROXMOX_TEMPLATE_NAME}"
+    full: "${TEST_PROXMOX_FULL_CLONE:-true}"
     debug: "${TEST_PROXMOX_DEBUG}"
 
 platforms:


### PR DESCRIPTION
Use the TEST_PROXMOX_FULL_CLONE env var to specify whether a full clone should be created during the tests. The default is true (create a full clone).  Set TEST_PROXMOX_FULL_CLONE to false to create linked clones which can reduce the test times, depending on how fast the drives are on the proxmox system.

Change the linked-clone scenario to always create a linked clone, because, well, it's a linked-clone test.